### PR TITLE
Remove JS Uri extensions

### DIFF
--- a/uri/src/jsMain/kotlin/com/eygraber/uri/JsUri.kt
+++ b/uri/src/jsMain/kotlin/com/eygraber/uri/JsUri.kt
@@ -1,7 +1,0 @@
-package com.eygraber.uri
-
-import org.w3c.dom.url.URL
-
-public fun Uri.toURL(): URL = URL(toString())
-
-public fun Uri.toURLOrNull(): URL? = runCatching { URL(toString()) }.getOrNull()

--- a/uri/src/jsMain/kotlin/com/eygraber/uri/JsUrl.kt
+++ b/uri/src/jsMain/kotlin/com/eygraber/uri/JsUrl.kt
@@ -1,0 +1,11 @@
+package com.eygraber.uri
+
+import org.w3c.dom.url.URL
+
+public fun Url.toURL(): URL = URL(toString())
+
+public fun Url.toURLOrNull(): URL? = runCatching { toURL() }.getOrNull()
+
+public fun URL.toUrl(): Url = Url.parse(toString())
+
+public fun URL.toUrlOrNull(): Url? = runCatching { toUrl() }.getOrNull()


### PR DESCRIPTION
  - Because JS uses URL which doesn't allow non-URL Uris, don't expose any interop with Uri